### PR TITLE
getGasPrice changed to use gas as coinmarketcap currency id

### DIFF
--- a/app/server/methods/wallet.js
+++ b/app/server/methods/wallet.js
@@ -21,7 +21,7 @@ Meteor.methods({
   },
   getGasPrice() {
     try {
-      const result = HTTP.call('GET', 'https://api.coinmarketcap.com/v1/ticker/Antcoin/?convert=USD');
+      const result = HTTP.call('GET', 'https://api.coinmarketcap.com/v1/ticker/gas/?convert=USD');
       return result.data;
     } catch (e) {
       return false;

--- a/app/server/methods/wallet.js
+++ b/app/server/methods/wallet.js
@@ -2,7 +2,7 @@ Meteor.methods({
   getWalletAmount() {
     try {
       if(Meteor.user().profile.walletAddress) {
-        const result = HTTP.call('GET', 'http://api.neonwallet.com/v1/address/balance/' + Meteor.user().profile.walletAddress);
+        const result = HTTP.call('GET', 'http://api.neonwallet.com/v2/address/balance/' + Meteor.user().profile.walletAddress);
         return result.data;
       } else {
         return false;


### PR DESCRIPTION
Coinmarketcap API no longer supports `Antcoin` as a currency id, switched to `gas` instead.